### PR TITLE
add 'SHOW NYC' to title

### DIFF
--- a/ionic_cms/www/index.html
+++ b/ionic_cms/www/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no, width=device-width">
-    <title></title>
+    <title>SHOW NYC</title>
 
     <link href="lib/ionic/css/ionic.css" rel="stylesheet">
     <link href="lib/ionic/css/jr-crop.scss" rel="stylesheet">


### PR DESCRIPTION
### Adds
- 'SHOW NYC' to index.html title element

This is because on some phones the title shows up on js alerts, and having index.html pop up with photo submission alerts looks terrible.
